### PR TITLE
added pinMode for non-standard CS pin

### DIFF
--- a/Adafruit_TinyFlash.cpp
+++ b/Adafruit_TinyFlash.cpp
@@ -57,9 +57,10 @@ static uint8_t spi_xfer(uint8_t n) {
 #endif
 
 // Constructor
-Adafruit_TinyFlash::Adafruit_TinyFlash(uint8_t cs) {
+Adafruit_TinyFlash::Adafruit_TinyFlash(uint8_t cs){
 #ifndef __AVR_ATtiny85__
 	cs_port = portOutputRegister(digitalPinToPort(cs));
+	cs_pin = cs;
 #endif
 	cs_mask = digitalPinToBitMask(cs);
 }
@@ -81,6 +82,7 @@ uint32_t Adafruit_TinyFlash::begin(void) {
               |   _BV(PORTB2)  // SCK
               |   cs_mask;     // CS
 #else
+	pinMode(cs_pin,OUTPUT);
 	SPI.begin();
 	// Resistor-based 5V->3.3V logic conversion is a little sloppy, so:
 	SPI.setClockDivider(SPI_CLOCK_DIV8); // 500 KHz

--- a/Adafruit_TinyFlash.h
+++ b/Adafruit_TinyFlash.h
@@ -24,8 +24,10 @@ class Adafruit_TinyFlash {
                     cmd(uint8_t c);
 #ifndef __AVR_ATtiny85__
   volatile uint8_t *cs_port;
+  uint8_t           cs_pin;
 #endif
   uint8_t           cs_mask;
+
 };
 
 #endif // _TINYFLASH_H_


### PR DESCRIPTION
Hi, Adafruit_TinyFlash constructor accepts non-standard CS pin, but without switching it in Output mode I wasn't able to work with my W25Q80DV memory chips. 
SPIClass::begin() from Arduino core library doesn't help since it switches to Output standard pin SS(PB2).

I added private member cs_pin, initialized it in the constructor and switched it into Output mode in Adafruit_TinyFlash::begin(). Afterward, I successfully tested it with AudioLoader.ino using pin8 as non-standard CD.